### PR TITLE
Optional server parameter & using native 'http' module

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,13 +1,21 @@
+#!/usr/bin/env node
+
 var express = require('express');
-var app = express();
-var server = require('http').createServer(app);
-var expressWs = require('../')(app, server);
+
+var expressWs = require('..')
+
+
+var app = expressWs(express());
+
+app.listen(3000)
+
 
 app.use(function (req, res, next) {
   console.log('middleware');
   req.testing = 'testing';
   return next();
 });
+
 
 app.get('/', function(req, res, next){
   console.log('get route', req.testing);
@@ -20,5 +28,3 @@ app.ws('/', function(ws, req) {
   });
   console.log('socket', req.testing);
 });
-
-server.listen(3000);

--- a/package.json
+++ b/package.json
@@ -9,10 +9,25 @@
   "author": "Henning Morud <henning@morud.org>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "ws": "~0.4.31",
-    "node-mocks-http": "~1.0.1"
+    "ws": "~0.4.31"
   },
   "devDependencies": {
     "express": "~4.0.0-rc3"
-  }
+  },
+  "directories": {
+    "example": "examples"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HenningM/express-ws"
+  },
+  "keywords": [
+    "express",
+    "ws",
+    "websocket"
+  ],
+  "bugs": {
+    "url": "https://github.com/HenningM/express-ws/issues"
+  },
+  "homepage": "https://github.com/HenningM/express-ws"
 }


### PR DESCRIPTION
This pull-request use the Node.js native 'http' module instead of the 'node-mocks-http' one, leveraging to less dependencies.

On the other hand, it also allow the 'server' parameter to be optional, but with some tricks: 'express' is protocol agnostic so it doesn't have any reference to its underlying http server, so I'm overriding the 'listen()' method to capture it, so it must be called before the WebSocket endpoint is enabled (I have updated the example showing it). Obviously, if the http server instance is created externally (not with the express 'listen()' method) then it must be passed as argument to express-ws enabler... :-)
