### PR TITLE
Add err into next fuction

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function (app, server) {
           } else {
             cur(ws.upgradeReq, response, next);
           }
-        }());
+        }(err));
       });
     });
   };


### PR DESCRIPTION
When use connect-timeout plugin, the router will execute twice.

Server: 

``` javascript
var express = require('express');
var timeout = require('connect-timeout');
var app = express();
var expressWs = require('express-ws');
var http = require('http');

function main(cb) {

    app.use(timeout('5s'));

    app.use(haltOnTimedout);

    var server = http.createServer(app);

    expressWs(app, server);
    // Listen on http port.
    server.listen(app.get('port'), function () {
        cb(server, app);
    });

}

function haltOnTimedout(req, res, next) {
    if (!req.timedout) next();
}

app.ws('/echo', function(ws, req){
  // 5s later, this will execute once again
  console.log('execute twice');
});

main(function(){
  console.log('start');
});

```
