### PR TITLE
Patch the wsPath resolution to work correctly with non-/ mountPaths

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,14 @@ var WebSocketServer = require('ws').Server;
 
 var wsServers = {};
 
+function resolvePath(mountpoint, route) {
+  mountpoint = (mountpoint + "/").replace("//", "/");
+  if (route.length > 0 && route.charAt(0) === "/") {
+    route = route.slice(1);
+  }
+  return url.resolve(mountpoint, route);
+};
+
 /**
  * @param {express.Application} app
  * @param {http.Server} [server]
@@ -21,7 +29,7 @@ module.exports = function (app, server) {
 
   function addSocketRoute(route, middleware, callback) {
     var args = [].splice.call(arguments, 0);
-    var wsPath = url.resolve(app.mountpath, route);
+    var wsPath = resolvePath(app.mountpath, route);
 
     if (args.length < 2)
       throw new SyntaxError('Invalid number of arguments');


### PR DESCRIPTION
While a PR was already made for this in #9, that solution does not work correctly when the mountPath is anything other than `/` - the algorithm for `url.resolve` differs from `path.join` in more ways than just the type of slash it uses (specifically in how it treats leading slashes).

This patch should fix that, and make sure that the wsPath *always* resolves correctly, for any value of the mountPath or route.