### PR TITLE
update ws@0.8.0;

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# editorconfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{html,js,ts,css,scss,xml,json}]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*output*]
+trim_trailing_whitespace = false

--- a/examples/broadcast.js
+++ b/examples/broadcast.js
@@ -4,17 +4,54 @@ var expressWs = require('..')
 var expressWs = expressWs(express());
 var app = expressWs.app;
 
-app.ws('/a', function(ws, req) {
+app.get('/', function (req, res) {
+  res.send(String(function () {
+    /*
+<!DOCTYPE html>
+<html>
+<head>
+  <mate charset="utf-8">
+</head>
+<body>
+  <div id="msgs"></div>
+</body>
+<script>
+var msgs = [];
+var host = location.href.slice(location.protocol.length + 2);
+console.log(host);
+var ws = new WebSocket('ws://' + host + 'a');
+ws.onopen = function (e) {
+  ws.send(Math.random().toString(36));
+};
+ws.onmessage = function (e) {
+  console.log(e);
+  msgs.push(e.data);
+  while (msgs.length > 30) {
+    msgs.shift();
+  }
+  document.querySelector('#msgs').innerHTML = msgs.join('<br>')
+};
+</script>
+</html>
+     */
+  }).match(/\/\*([^]*)\*\//)[1]);
 });
+
+app.ws('/a', function (client, req) {
+  client.on('message', function (message) {
+    client._lastMessage = message;
+    client.send('welcome.' + message);
+  });
+});
+
 var aWss = expressWs.getWss('/a');
 
-app.ws('/b', function(ws, req) {
-});
+app.ws('/b', function (client, req) {});
 
 setInterval(function () {
   aWss.clients.forEach(function (client) {
-    client.send('hello');
+    client.send('hello ' + client._lastMessage);
   });
 }, 5000);
 
-app.listen(3000)
+app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
-    "url-join": "0.0.1",
-    "ws": "~0.4.31"
+    "url-join": "^0.0.1",
+    "ws": "^0.8.0"
   },
   "devDependencies": {
-    "express": "~4.0.0-rc3"
+    "express": "^4.13.3"
   },
   "directories": {
     "example": "examples"


### PR DESCRIPTION
update express@4.13.3;
update examples/broadcast.js

ws:fixed:Installation on Windows (win7) fails [#240](https://github.com/websockets/ws/issues/240)