### PR TITLE
Return "this" to allow for chaining in Router

### DIFF
--- a/src/add-ws-method.js
+++ b/src/add-ws-method.js
@@ -20,6 +20,11 @@ export default function addWsMethod(target) {
        * directly, it's just to let our request propagate internally, so that we can
        * leave the regular middleware execution and error handling to Express. */
       this.get.apply(this, [wsRoute].concat(wrappedMiddlewares));
+      
+      /*
+       * Return `this` to allow for chaining:
+       */
+      return this;
     };
   }
 }


### PR DESCRIPTION
Currently, using `express-ws`, this kind of code is not allowed (because `app.ws(...)` returns undefined):

```js
app.use('/ws', express.Router()
    .ws('/:id', function (ws, req) { ... })
    .ws('/another-route', function (ws, req) { ... }))
```

This pull request allows for this type of router-chaining to be possible, just like the native `express.Router` does.