### PR TITLE
An attempt to achieve issue #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,42 @@ Sets up `express-ws` on the given `router` (or other Router-like object). You wi
 
 In most cases, you won't need this at all.
 
+### app.ws(path, ...middlewares)
+
+Set middlewares to handle WebSocket request after connection establishes.
+
+Signature of a middleware (same below): `function(ws, req)`, where `ws` is as in [ws](https://www.npmjs.com/package/ws) module.
+
+### app.wsError(path, ...middlewares)
+
+Set middlewares to handle WebSocket connection when an error event occurs.
+
+It will set `req.wsParams.error` for error message as in callback parameter of `ws.onError`.
+
+Things are similar below.
+
+### app.wsClose(path, ...middlewares)
+
+Will set `req.wsParams.code` and `req.wsParams.message`.
+
+### app.wsMessage(path, ...middlewares)
+
+Will set `req.wsParams.data` and `req.wsParams.flags`.
+
+### app.wsPing(path, ...middlewares)
+
+Will set `req.wsParams.data` and `req.wsParams.flags`.
+
+### app.wsPong(path, ...middlewares)
+
+Will set `req.wsParams.data` and `req.wsParams.flags`.
+
+### app.wsOpen(path, ...middlewares)
+
+Will set nothing extra.
+
+All methods added to `app` will also be added to `Router` if `leaveRouterUntouched` is off.
+
 ## Development
 
 This module is written in ES6, and uses Babel for compilation. What this means in practice:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ router.ws('/echo', function(ws, req) {
 app.use("/ws-stuff", router);
 ```
 
+We can also listen to the socket when receiving a message rather than when the connection establishes, using `wsMessage`, `wsOpen`, `wsClose`, `wsPing`, `wsPong`, `wsError` methods. This helps passing the message through middlewares. The original parameters of the callback function are stored in `req.wsParams`:
+
+```javascript```
+app.wsMessage("/", function(ws, req, next) {
+    ws.send("1: "+req.wsParams.data); // this will be sent.
+    next();
+});
+
+app.wsMessage("/", function(ws, req, next) {
+    ws.send("2: "+req.wsParams.data); // this will be sent, too.
+});
+
+app.wsMessage("/", function(ws, req) {
+    ws.send("3: "+req.wsParams.data); // this won't be sent.
+});
+```
+
 ## Full example
 
 ```javascript

--- a/src/add-ws-method.js
+++ b/src/add-ws-method.js
@@ -2,29 +2,42 @@ import wrapMiddleware from './wrap-middleware';
 import websocketUrl from './websocket-url';
 
 export default function addWsMethod(target) {
-  /* This prevents conflict with other things setting `.ws`. */
-  if (target.ws === null || target.ws === undefined) {
-    target.ws = function addWsRoute(route, ...middlewares) {
-      const wrappedMiddlewares = middlewares.map(wrapMiddleware);
+  /* We add methods to recieve other events, too. */
+  const urlSuffix = {
+    ws: '', // Compatible with the old suffix
+    wsError: 'error',
+    wsClose: 'close',
+    wsMessage: 'message',
+    wsPing: 'ping',
+    wsPong: 'pong',
+    wsOpen: 'open'
+  };
 
-      /* We append `/.websocket` to the route path here. Why? To prevent conflicts when
-       * a non-WebSocket request is made to the same GET route - after all, we are only
-       * interested in handling WebSocket requests.
-       *
-       * Whereas the original `express-ws` prefixed this path segment, we suffix it -
-       * this makes it possible to let requests propagate through Routers like normal,
-       * which allows us to specify WebSocket routes on Routers as well \o/! */
-      const wsRoute = websocketUrl(route);
+  for (const method in urlSuffix) {
+    /* This prevents conflict with other things setting the same method names. */
+    if (target[method] === null || target[method] === undefined) {
+      target[method] = function addWsRoute(route, ...middlewares) {
+        const wrappedMiddlewares = middlewares.map(wrapMiddleware);
 
-      /* Here we configure our new GET route. It will never get called by a client
-       * directly, it's just to let our request propagate internally, so that we can
-       * leave the regular middleware execution and error handling to Express. */
-      this.get.apply(this, [wsRoute].concat(wrappedMiddlewares));
+        /* We append `/.websocket` to the route path here. Why? To prevent conflicts when
+         * a non-WebSocket request is made to the same GET route - after all, we are only
+         * interested in handling WebSocket requests.
+         *
+         * Whereas the original `express-ws` prefixed this path segment, we suffix it -
+         * this makes it possible to let requests propagate through Routers like normal,
+         * which allows us to specify WebSocket routes on Routers as well \o/! */
+        const wsRoute = websocketUrl(route, urlSuffix[method]);
 
-      /*
-       * Return `this` to allow for chaining:
-       */
-      return this;
-    };
+        /* Here we configure our new GET route. It will never get called by a client
+         * directly, it's just to let our request propagate internally, so that we can
+         * leave the regular middleware execution and error handling to Express. */
+        this.get.apply(this, [wsRoute].concat(wrappedMiddlewares));
+
+        /*
+         * Return `this` to allow for chaining:
+         */
+        return this;
+      };
+    }
   }
 }

--- a/src/add-ws-method.js
+++ b/src/add-ws-method.js
@@ -33,6 +33,10 @@ export default function addWsMethod(target) {
          * leave the regular middleware execution and error handling to Express. */
         this.get.apply(this, [wsRoute].concat(wrappedMiddlewares));
 
+        /* Prevent the socket from being closed automatically */
+        if (method != 'ws')
+          this.ws(route, (ws, req, next) => { next(); });
+
         /*
          * Return `this` to allow for chaining:
          */

--- a/src/index.js
+++ b/src/index.js
@@ -40,25 +40,33 @@ export function expressWs(app, httpServer, options = {}) {
   const wsServer = new ws.Server({ server });
 
   wsServer.on('connection', (socket) => {
-    const request = socket.upgradeReq;
+    const newRequest = function() {
+      const request = { ws: socket, wsHandled: false };
+      Object.assign(request, socket.upgradeReq);
+      request.__proto__ = socket.upgradeReq.__proto__;
+      return request;
+    };
 
-    request.ws = socket;
-    request.wsHandled = false;
+    const newResponse = function(request) {
+      const dummyResponse = new http.ServerResponse(request);
+
+      dummyResponse.writeHead = function writeHead(statusCode) {
+        if (statusCode > 200) {
+          /* Something in the middleware chain signalled an error. */
+          socket.close();
+        }
+      };
+
+      return dummyResponse;
+    };
+
+    const request = newRequest();
+    const dummyResponse = newResponse(request);
 
     /* By setting this fake `.url` on the request, we ensure that it will end up in the fake
      * `.get` handler that we defined above - where the wrapper will then unpack the `.ws`
      * property, indicate that the WebSocket has been handled, and call the actual handler. */
-    const originalUrl = request.url;
     request.url = websocketUrl(request.url);
-
-    const dummyResponse = new http.ServerResponse(request);
-
-    dummyResponse.writeHead = function writeHead(statusCode) {
-      if (statusCode > 200) {
-        /* Something in the middleware chain signalled an error. */
-        socket.close();
-      }
-    };
 
     app.handle(request, dummyResponse, () => {
       if (!request.wsHandled) {
@@ -71,32 +79,44 @@ export function expressWs(app, httpServer, options = {}) {
     /* We send GET requests on every events in order to let users use Express middleware
      * chains to handle these events */
     socket.on("error", function(error) {
-      request.url = websocketUrl(originalUrl, "error");
+      const request = newRequest();
+      const dummyResponse = newResponse(request);
+      request.url = websocketUrl(request.url, "error");
       request.wsParams = { error };
       app.handle(request, dummyResponse);
     });
     socket.on("close", function(code, message) {
-      request.url = websocketUrl(originalUrl, "close");
+      const request = newRequest();
+      const dummyResponse = newResponse(request);
+      request.url = websocketUrl(request.url, "close");
       request.wsParams = { code, message };
       app.handle(request, dummyResponse);
     });
     socket.on("message", function(data, flags) {
-      request.url = websocketUrl(originalUrl, "message");
+      const request = newRequest();
+      const dummyResponse = newResponse(request);
+      request.url = websocketUrl(request.url, "message");
       request.wsParams = { data, flags };
       app.handle(request, dummyResponse);
     });
     socket.on("ping", function(data, flags) {
-      request.url = websocketUrl(originalUrl, "ping");
+      const request = newRequest();
+      const dummyResponse = newResponse(request);
+      request.url = websocketUrl(request.url, "ping");
       request.wsParams = { data, flags };
       app.handle(request, dummyResponse);
     });
     socket.on("pong", function(data, flags) {
-      request.url = websocketUrl(originalUrl, "pong");
+      const request = newRequest();
+      const dummyResponse = newResponse(request);
+      request.url = websocketUrl(request.url, "pong");
       request.wsParams = { data, flags };
       app.handle(request, dummyResponse);
     });
     socket.on("open", function() {
-      request.url = websocketUrl(originalUrl, "open");
+      const request = newRequest();
+      const dummyResponse = newResponse(request);
+      request.url = websocketUrl(request.url, "open");
       request.wsParams = {};
       app.handle(request, dummyResponse);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export function expressWs(app, httpServer, options = {}) {
       if (!request.wsHandled) {
         /* There was no matching WebSocket-specific route for this request. We'll close
          * the connection, as no endpoint was able to handle the request anyway... */
-        // socket.close(); // This will close the connection before listeners below catch it.
+        socket.close();
       }
     });
 

--- a/src/websocket-url.js
+++ b/src/websocket-url.js
@@ -1,11 +1,13 @@
 import trailingSlash from './trailing-slash';
 
 /* The following fixes HenningM/express-ws#17, correctly. */
-export default function websocketUrl(url) {
+export default function websocketUrl(url, eventName) {
+  if (eventName === null || eventName === undefined)
+    eventName = '';
   if (url.indexOf('?') !== -1) {
     const [baseUrl, query] = url.split('?');
 
-    return `${trailingSlash(baseUrl)}.websocket?${query}`;
+    return `${trailingSlash(baseUrl)}.websocket.${eventName}?${query}`;
   }
-  return `${trailingSlash(url)}.websocket`;
+  return `${trailingSlash(url)}.websocket.${eventName}`;
 }


### PR DESCRIPTION
I send different GET requests to different fake address responding to "message", "open", "close" events, etc.

README.md is slightly changed and the usage can be referred there.

I tried not to disturb the original API, but I had to turn off the feature that automatically closes the connection when no middlewares handling it.
