### PR TITLE
Passing options to ws

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Sets up `express-ws` on the specified `app`. This will modify the global Router 
 * __server__: *Optional.* When using a custom `http.Server`, you should pass it in here, so that `express-ws` can use it to set up the WebSocket upgrade handlers. If you don't specify a `server`, you will only be able to use it with the server that is created automatically when you call `app.listen`.
 * __options__: *Optional.* An object containing further options.
   * __leaveRouterUntouched:__ Set this to `true` to keep `express-ws` from modifying the Router prototype. You will have to manually `applyTo` every Router that you wish to make `.ws` available on, when this is enabled.
+  * __wsOptions:__ Options object passed to WebSocketServer constructor. Necessary for any ws specific features.
 
 This function will return a new `express-ws` API object, which will be referred to as `wsInstance` in the rest of the documentation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-ws",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.1.1",
   "description": "WebSocket endpoints for Express applications",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,10 @@ export function expressWs(app, httpServer, options = {}) {
     addWsMethod(express.Router);
   }
 
-  const wsServer = new ws.Server({ server });
+  // allow caller to pass in options to WebSocketServer constructor
+  var wsOptions = options.wsOptions || {};
+  wsOptions.server = server;
+  const wsServer = new ws.Server(wsOptions);
 
   wsServer.on('connection', (socket) => {
     const request = socket.upgradeReq;


### PR DESCRIPTION
Since express-ws is responsible for constructing the ws server, need the ability to pass in the advanced options object to it. Totally optional and doesn't require much change as you can see.

In my case I specifically needed to handle verifyClient in the ws server.