### PR TITLE
Forward return value from http.Server's listen() to allow chaining

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export function expressWs(app, httpServer, options = {}) {
     server = http.createServer(app);
 
     app.listen = function serverListen() {
-      server.listen.apply(server, arguments);
+      return server.listen.apply(server, arguments);
     };
   }
 


### PR DESCRIPTION
When using `express` without `express-ws`, the following works:

```
const port = 80;
app
  .listen(port)
  .on('listening', () => {
    console.log(`listening on port ${port}...`);
  });
```

Patching `express` with `express-ws` breaks this, because `listen()` now returns `undefined`. For express' implementation of `listen()`, see [here](https://github.com/expressjs/express/blob/3c54220a3495a7a2cdf580c3289ee37e835c0190/lib/application.js#L617).

This PR simply forwards the return value from `server.listen()` to allow chaining calls again.