### PR TITLE
Get rid of warning when using Express 5 (alpha.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-ws",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "WebSocket endpoints for Express applications",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "ws": "^1.0.0"
   },
   "peerDependencies": {
-    "express": "^4.0.0"
+    "express": "^4.0.0 || ^5.0.0-alpha.2"
   },
   "directories": {
     "example": "examples"


### PR DESCRIPTION
Solution for issue https://github.com/HenningM/express-ws/issues/44
Getting rid of npm missing peer dependency warning when using express@5.0.0. Version bump to 2.0.1.
