### PR TITLE
If an error is thrown while calling the WS middleware - next that

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Sven Slootweg <admin@cryto.net>",
     "Andrew Phillips <theasp@gmail.com>",
     "Nicholas Schell <nschell@gmail.com>",
-    "Max Truxa <dev@maxtruxa.com>"
+    "Max Truxa <dev@maxtruxa.com>",
+    "Kræn Hansen <mail@kraenhansen.dk>"
   ],
   "license": "BSD-2-Clause",
   "dependencies": {

--- a/src/wrap-middleware.js
+++ b/src/wrap-middleware.js
@@ -2,8 +2,13 @@ export default function wrapMiddleware(middleware) {
   return (req, res, next) => {
     if (req.ws !== null && req.ws !== undefined) {
       req.wsHandled = true;
-      /* Unpack the `.ws` property and call the actual handler. */
-      middleware(req.ws, req, next);
+      try {
+        /* Unpack the `.ws` property and call the actual handler. */
+        middleware(req.ws, req, next);
+      } catch (err) {
+        /* If an error is thrown, let's send that on to any error handling */
+        next(err);
+      }
     } else {
       /* This wasn't a WebSocket request, so skip this middleware. */
       next();


### PR DESCRIPTION
First take on fixing error handling is to send any errors thrown along the list of middleware using the next function.

This fixes at least some of the variants of https://github.com/HenningM/express-ws/issues/19