### PR TITLE
Add RegExp path support

### DIFF
--- a/src/add-ws-method.js
+++ b/src/add-ws-method.js
@@ -1,5 +1,5 @@
 import wrapMiddleware from './wrap-middleware';
-import websocketUrl from './websocket-url';
+import websocketRoute from './websocket-route';
 
 export default function addWsMethod(target) {
   /* This prevents conflict with other things setting `.ws`. */
@@ -14,7 +14,7 @@ export default function addWsMethod(target) {
        * Whereas the original `express-ws` prefixed this path segment, we suffix it -
        * this makes it possible to let requests propagate through Routers like normal,
        * which allows us to specify WebSocket routes on Routers as well \o/! */
-      const wsRoute = websocketUrl(route);
+      const wsRoute = websocketRoute(route);
 
       /* Here we configure our new GET route. It will never get called by a client
        * directly, it's just to let our request propagate internally, so that we can

--- a/src/trailing-slash.js
+++ b/src/trailing-slash.js
@@ -1,7 +1,0 @@
-export default function addTrailingSlash(string) {
-  let suffixed = string;
-  if (suffixed.charAt(suffixed.length - 1) !== '/') {
-    suffixed = `${suffixed}/`;
-  }
-  return suffixed;
-}

--- a/src/websocket-route.js
+++ b/src/websocket-route.js
@@ -1,0 +1,12 @@
+/**
+ * Converts an express URL into a 'websocket' URL by appending .websocket
+ * to the path. Preserves trailing slashes and works on most RegExp routes
+ * as well.
+ * @param {string|RegExp} url express URL to modify
+ */
+export default function websocketRoute(url) {
+  if (url instanceof RegExp) {
+    return new RegExp(url.source.replace(/(\/)?(\$)?$/, '/.websocket$1$2'), url.flags);
+  }
+  return url.replace(/(\/)?$/, '/.websocket$1');
+}

--- a/src/websocket-url.js
+++ b/src/websocket-url.js
@@ -1,11 +1,8 @@
-import trailingSlash from './trailing-slash';
-
-/* The following fixes HenningM/express-ws#17, correctly. */
+/**
+ * Converts a request URL into a websocket URL. Preserves trailing
+ * slashes and correctly handles query params and hash fragments.
+ * @param {string} url Request URL to process
+ */
 export default function websocketUrl(url) {
-  if (url.indexOf('?') !== -1) {
-    const [baseUrl, query] = url.split('?');
-
-    return `${trailingSlash(baseUrl)}.websocket?${query}`;
-  }
-  return `${trailingSlash(url)}.websocket`;
+  return url.replace(/(\/)?((?:\?|#).*)?$/, '/.websocket$1$2');
 }


### PR DESCRIPTION
Added support for modifying RegExp paths. Also fixed a few bugs, including: properly handling hash url elements, preserving trailing slashes in URLs, and supporting optional express url params (ala :param?)