### PR TITLE
Fix https://github.com/HenningM/express-ws/issues/64 by setting a str…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ export default function expressWs(app, httpServer, options = {}) {
     dummyResponse.writeHead = function writeHead(statusCode) {
       if (statusCode > 200) {
         /* Something in the middleware chain signalled an error. */
+        dummyResponse._header = '';
         socket.close();
       }
     };


### PR DESCRIPTION
…ing in the _header property of the response.

I also ran into this issue: https://github.com/HenningM/express-ws/issues/64
According to dougwilson https://github.com/HenningM/express-ws/issues/64#issuecomment-315092334 who seems to be an Express maintainer, the problem was this missing property. 

Now, I have done this patch without a thorough understanding of your library, and without diving deeply into dougwilson's answer, but it seems to fix the problem for me.

Maybe this will help some other people, too.