### PR TITLE
Return the middleware's result so that async error handling works.

### DIFF
--- a/src/wrap-middleware.js
+++ b/src/wrap-middleware.js
@@ -4,7 +4,7 @@ export default function wrapMiddleware(middleware) {
       req.wsHandled = true;
       try {
         /* Unpack the `.ws` property and call the actual handler. */
-        middleware(req.ws, req, next);
+        return middleware(req.ws, req, next);
       } catch (err) {
         /* If an error is thrown, let's send that on to any error handling */
         next(err);


### PR DESCRIPTION
By returning the result of the middleware, promise chaining can be done elsewhere. An example of why this is (very) useful is given by

https://github.com/N-McA/express-ws-async-error-fail-example

Which shows the lack of interoperability that occurs without the suggested change.