### PR TITLE
Testing/Coverage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "extends": "airbnb/base",
-    "rules": {
-      "comma-dangle": 0,
-      "no-param-reassign": 0
-    }
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "extends": "airbnb/base",
+  "overrides": [
+    {
+      "files": "examples/**",
+      "rules": {
+        "no-console": 0
+      }
+    }
+  ],
+  "rules": {
+    "comma-dangle": 0,
+    "no-param-reassign": 0
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,19 @@
   "extends": "airbnb/base",
   "overrides": [
     {
-      "files": "examples/**",
+      "files": ["examples/**"],
+      "rules": {
+        "no-console": 0
+      }
+    },
+    {
+      "files": ["test/**"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "expect": true
+      },
       "rules": {
         "no-console": 0
       }

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src/
+test/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ __Full documentation can be found in the API section below. This section only sh
 Add this line to your Express application:
 
 ```javascript
-var expressWs = require('express-ws')(app);
+const expressWs = require('express-ws')(app);
 ```
 
 __Important: Make sure to set up the `express-ws` module like above *before* loading or defining your routers!__ Otherwise, `express-ws` won't get a chance to set up support for Express routers, and you might run into an error along the lines of `router.ws is not a function`.
@@ -21,8 +21,8 @@ __Important: Make sure to set up the `express-ws` module like above *before* loa
 After setting up `express-ws`, you will be able to add WebSocket routes (almost) the same way you add other routes. The following snippet sets up a simple echo server at `/echo`.  The `ws` parameter is an instance of the WebSocket class described [here](https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocket).
 
 ```javascript
-app.ws('/echo', function(ws, req) {
-  ws.on('message', function(msg) {
+app.ws('/echo', (ws, req) => {
+  ws.on('message', (msg) => {
     ws.send(msg);
   });
 });
@@ -31,10 +31,10 @@ app.ws('/echo', function(ws, req) {
 It works with routers, too, this time at `/ws-stuff/echo`:
 
 ```javascript
-var router = express.Router();
+const router = express.Router();
 
-router.ws('/echo', function(ws, req) {
-  ws.on('message', function(msg) {
+router.ws('/echo', (ws, req) => {
+  ws.on('message', (msg) => {
     ws.send(msg);
   });
 });
@@ -45,23 +45,23 @@ app.use("/ws-stuff", router);
 ## Full example
 
 ```javascript
-var express = require('express');
-var app = express();
-var expressWs = require('express-ws')(app);
+const express = require('express');
+const app = express();
+const expressWs = require('express-ws')(app);
 
-app.use(function (req, res, next) {
+app.use((req, res, next) => {
   console.log('middleware');
   req.testing = 'testing';
   return next();
 });
 
-app.get('/', function(req, res, next){
+app.get('/', (req, res, next) => {
   console.log('get route', req.testing);
   res.end();
 });
 
-app.ws('/', function(ws, req) {
-  ws.on('message', function(msg) {
+app.ws('/', (ws, req) => {
+  ws.on('message', (msg) => {
     console.log(msg);
   });
   console.log('socket', req.testing);

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ router.ws('/echo', (ws, req) => {
   });
 });
 
-app.use("/ws-stuff", router);
+app.use('/ws-stuff', router);
 ```
 
 ## Full example
@@ -80,26 +80,26 @@ Sets up `express-ws` on the specified `app`. This will modify the global Router 
 * __server__: *Optional.* When using a custom `http.Server`, you should pass it in here, so that `express-ws` can use it to set up the WebSocket upgrade handlers. If you don't specify a `server`, you will only be able to use it with the server that is created automatically when you call `app.listen`.
 * __options__: *Optional.* An object containing further options.
   * __leaveRouterUntouched:__ Set this to `true` to keep `express-ws` from modifying the Router prototype. You will have to manually `applyTo` every Router that you wish to make `.ws` available on, when this is enabled.
-  * __wsOptions:__ Options object passed to WebSocketServer constructor. Necessary for any ws specific features.
+  * __wsOptions:__ Options object passed to `ws.Server` constructor. Necessary for any ws specific features.
 
-This function will return a new `express-ws` API object, which will be referred to as `wsInstance` in the rest of the documentation.
+This function will return a new `express-ws` API object, which will be referred to as `expressWsInstance` in the rest of the documentation.
 
-### wsInstance.app
+### expressWsInstance.app
 
 This property contains the `app` that `express-ws` was set up on.
 
-### wsInstance.getWss()
+### expressWsInstance.getWss()
 
-Returns the underlying WebSocket server/handler. You can use `wsInstance.getWss().clients` to obtain a list of all the connected WebSocket clients for this server.
+Returns the underlying WebSocket server/handler. You can use `expressWsInstance.getWss().clients` to obtain a list of all the connected WebSocket clients for this server.
 
 Note that this list will include *all* clients, not just those for a specific route - this means that it's often *not* a good idea to use this for broadcasts, for example.
 
-### wsInstance.applyTo(router)
+### expressWsInstance.applyTo(router)
 
 Sets up `express-ws` on the given `router` (or other Router-like object). You will only need this in two scenarios:
 
 1. You have enabled `options.leaveRouterUntouched`, or
-2. You are using a custom router that is not based on the express.Router prototype.
+2. You are using a custom router that is not based on the `express.Router` prototype.
 
 In most cases, you won't need this at all.
 

--- a/examples/broadcast.js
+++ b/examples/broadcast.js
@@ -6,13 +6,13 @@ const app = expressWs.app;
 
 app.ws('/a', (/* ws, req */) => {
 });
-const aWss = expressWs.getWss('/a');
+const wss = expressWs.getWss();
 
 app.ws('/b', (/* ws, req */) => {
 });
 
 setInterval(() => {
-  aWss.clients.forEach((client) => {
+  wss.clients.forEach((client) => {
     client.send('hello');
   });
 }, 5000);

--- a/examples/broadcast.js
+++ b/examples/broadcast.js
@@ -1,20 +1,20 @@
-var express = require('express');
-var expressWs = require('..')
+const express = require('express');
+let expressWs = require('..');
 
-var expressWs = expressWs(express());
-var app = expressWs.app;
+expressWs = expressWs(express());
+const app = expressWs.app;
 
-app.ws('/a', function(ws, req) {
+app.ws('/a', (/* ws, req */) => {
 });
-var aWss = expressWs.getWss('/a');
+const aWss = expressWs.getWss('/a');
 
-app.ws('/b', function(ws, req) {
+app.ws('/b', (/* ws, req */) => {
 });
 
-setInterval(function () {
-  aWss.clients.forEach(function (client) {
+setInterval(() => {
+  aWss.clients.forEach((client) => {
     client.send('hello');
   });
 }, 5000);
 
-app.listen(3000)
+app.listen(3000);

--- a/examples/https.js
+++ b/examples/https.js
@@ -1,33 +1,33 @@
-var https = require('https');
-var fs = require('fs');
+const https = require('https');
+const fs = require('fs');
 
-var express = require('express');
-var expressWs = require('..');
+const express = require('express');
+const expressWs = require('..');
 
-var options = {
+const options = {
   key: fs.readFileSync('key.pem'),
   cert: fs.readFileSync('cert.pem')
 };
-var app = express();
-var server = https.createServer(options, app);
-var expressWs = expressWs(app, server);
+const app = express();
+const server = https.createServer(options, app);
+expressWs(app, server);
 
-app.use(function (req, res, next) {
+app.use((req, res, next) => {
   console.log('middleware');
   req.testing = 'testing';
   return next();
 });
 
-app.get('/', function(req, res, next){
+app.get('/', (req, res /* , next */) => {
   console.log('get route', req.testing);
   res.end();
 });
 
-app.ws('/', function(ws, req) {
-  ws.on('message', function(msg) {
+app.ws('/', (ws, req) => {
+  ws.on('message', (msg) => {
     console.log(msg);
   });
   console.log('socket', req.testing);
 });
 
-server.listen(3000)
+server.listen(3000);

--- a/examples/params.js
+++ b/examples/params.js
@@ -1,26 +1,26 @@
-var express = require('express');
-var expressWs = require('..');
+const express = require('express');
+let expressWs = require('..');
 
-var expressWs = expressWs(express());
-var app = expressWs.app;
+expressWs = expressWs(express());
+const app = expressWs.app;
 
-app.param('world', function (req, res, next, world) {
+app.param('world', (req, res, next, world) => {
   req.world = world || 'world';
   return next();
 });
 
-app.get('/hello/:world', function(req, res, next){
+app.get('/hello/:world', (req, res, next) => {
   console.log('hello', req.world);
   res.end();
   next();
 });
 
-app.ws('/hello/:world', function(ws, req, next) {
-  ws.on('message', function(msg) {
+app.ws('/hello/:world', (ws, req, next) => {
+  ws.on('message', (msg) => {
     console.log(msg);
   });
   console.log('socket hello', req.world);
   next();
 });
 
-app.listen(3000)
+app.listen(3000);

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,25 +1,25 @@
-var express = require('express');
-var expressWs = require('..');
+const express = require('express');
+let expressWs = require('..');
 
-var expressWs = expressWs(express());
-var app = expressWs.app;
+expressWs = expressWs(express());
+const app = expressWs.app;
 
-app.use(function (req, res, next) {
+app.use((req, res, next) => {
   console.log('middleware');
   req.testing = 'testing';
   return next();
 });
 
-app.get('/', function(req, res, next){
+app.get('/', (req, res /* , next */) => {
   console.log('get route', req.testing);
   res.end();
 });
 
-app.ws('/', function(ws, req) {
-  ws.on('message', function(msg) {
+app.ws('/', (ws, req) => {
+  ws.on('message', (msg) => {
     console.log(msg);
   });
   console.log('socket', req.testing);
 });
 
-app.listen(3000)
+app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index",
   "module": "src/index",
   "scripts": {
-    "lint": "eslint src/"
+    "lint": "eslint ."
   },
   "author": "Henning Morud <henning@morud.org>",
   "contributors": [
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/HenningM/express-ws",
   "devDependencies": {
     "eslint": "^4.19.0",
-    "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-airbnb": "^15.1.0",
     "eslint-plugin-import": "^2.12.0",
     "express": "^5.0.0-alpha.6"
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index",
   "module": "src/index",
   "scripts": {
+    "mocha": "mocha --require esm --require chai/register-expect --timeout 20000 test",
+    "test": "echo 'Blanking out cache for ESM/nyc that can get corrupted by terminated processes...' && rm -Rf ./node_modules/.cache && nyc npm run mocha",
     "lint": "eslint ."
   },
   "author": "Henning Morud <henning@morud.org>",
@@ -18,13 +20,6 @@
     "Alexis Tyler <xo@wvvw.me>"
   ],
   "license": "BSD-2-Clause",
-  "dependencies": {
-    "esm": "^3.0.84",
-    "ws": "^6.0.0"
-  },
-  "peerDependencies": {
-    "express": "^4.0.0 || ^5.0.0-alpha.1"
-  },
   "engines": {
     "node": ">=4.5.0"
   },
@@ -44,10 +39,21 @@
     "url": "https://github.com/HenningM/express-ws/issues"
   },
   "homepage": "https://github.com/HenningM/express-ws",
+  "dependencies": {
+    "esm": "^3.0.84",
+    "ws": "^6.0.0"
+  },
+  "peerDependencies": {
+    "express": "^4.0.0 || ^5.0.0-alpha.1"
+  },
   "devDependencies": {
+    "chai": "^4.2.0",
     "eslint": "^4.19.0",
     "eslint-config-airbnb": "^15.1.0",
     "eslint-plugin-import": "^2.12.0",
-    "express": "^5.0.0-alpha.6"
+    "express": "^5.0.0-alpha.6",
+    "got": "^11.4.0",
+    "mocha": "^8.0.1",
+    "nyc": "^15.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -43,10 +43,6 @@ export default function expressWs(app, httpServer, options = {}) {
   const wsServer = new ws.Server(wsOptions);
 
   wsServer.on('connection', (socket, request) => {
-    if ('upgradeReq' in socket) {
-      request = socket.upgradeReq;
-    }
-
     request.ws = socket;
     request.wsHandled = false;
 

--- a/src/wrap-middleware.js
+++ b/src/wrap-middleware.js
@@ -1,4 +1,19 @@
 export default function wrapMiddleware(middleware) {
+  if (middleware.length === 4) {
+    return (error, req, res, next) => {
+      // Not checking for `req.ws` here as error shouldn't be reached if
+      //   no middleware is available to run first (and that would be
+      //   handled below)
+      req.wsHandled = true;
+      try {
+        /* Unpack the `.ws` property and call the actual handler. */
+        middleware(error, req.ws, req, next);
+      } catch (err) {
+        /* If an error is thrown, let's send that on to any error handling */
+        next(err);
+      }
+    };
+  }
   return (req, res, next) => {
     if (req.ws !== null && req.ws !== undefined) {
       req.wsHandled = true;

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,537 @@
+import http from 'http';
+import express from 'express';
+import WebSocket from 'ws';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import got from 'got';
+import expressWs from '../src';
+
+describe('Simple usage', () => {
+  it('Sets up Web Sockets server', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    app.use((req, res, next) => {
+      messages.push('middleware');
+      req.testing = 'testing';
+      return next();
+    });
+
+    app.get('/', (req, res /* , next */) => {
+      messages.push(`get route ${req.testing}`);
+      res.end();
+    });
+
+    app.ws('/', (ws, req) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        ws.send('server response');
+      });
+      messages.push('socket', req.testing);
+    });
+
+    const server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', async (data) => {
+      messages.push(data);
+      expect(messages).to.deep.equal([
+        'middleware',
+        'socket',
+        'testing',
+        'something',
+        'server response'
+      ]);
+      await got('http://localhost:3000/');
+      expect(messages.pop()).to.equal('get route testing');
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      expressWsInstance.getWss().close(); // Close WS server
+      done();
+    });
+  });
+
+  it('Sets up Web Sockets server (supplying own HTTP server)', (done) => {
+    const app = express();
+    const server = http.createServer(app).listen(3000);
+    const expressWsInstance = expressWs(app, server);
+
+    const messages = [];
+
+    app.use((req, res, next) => {
+      messages.push('middleware');
+      req.testing = 'testing';
+      return next();
+    });
+
+    app.get('/', (req, res /* , next */) => {
+      messages.push(`get route ${req.testing}`);
+      res.end();
+    });
+
+    app.ws('/', (ws, req) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        ws.send('server response');
+      });
+      messages.push('socket', req.testing);
+    });
+
+    const ws = new WebSocket('ws://localhost:3000/');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', async (data) => {
+      messages.push(data);
+      expect(messages).to.deep.equal([
+        'middleware',
+        'socket',
+        'testing',
+        'something',
+        'server response'
+      ]);
+      await got('http://localhost:3000/');
+      expect(messages.pop()).to.equal('get route testing');
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      expressWsInstance.getWss().close(); // Close WS server
+      done();
+    });
+  });
+
+  it('Passes on query string', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    app.get('/', (req, res /* , next */) => {
+      messages.push(`get route ${req.url}`);
+      res.end();
+    });
+
+    app.ws('/', (ws, req) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        ws.send('server response');
+      });
+      messages.push('socket', req.url);
+    });
+
+    const server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/?abc=1');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', async (data) => {
+      messages.push(data);
+      expect(messages).to.deep.equal([
+        'socket',
+        '/.websocket?abc=1',
+        'something',
+        'server response'
+      ]);
+      await got('http://localhost:3000/?abc=2');
+      expect(messages.pop()).to.equal('get route /?abc=2');
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      expressWsInstance.getWss().close(); // Close WS server
+      done();
+    });
+  });
+});
+
+describe('Router', () => {
+  it('Silently recovers with HTTP requests passed through the underlying app', (done) => {
+    const expressWsInstance = expressWs(express(), null, {
+      leaveRouterUntouched: true
+    });
+    const { app, applyTo } = expressWsInstance;
+
+    const messages = [];
+
+    const router = express.Router();
+
+    applyTo(router);
+
+    app.get('/ws-stuff/echo', (req, res /* , next */) => {
+      messages.push(`get route ${req.url}`);
+      res.end();
+    });
+
+    router.ws('/echo', (ws, req) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        ws.send('server response');
+      });
+      messages.push('socket', req.url);
+    });
+
+    app.use('/ws-stuff', router);
+
+    const server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/ws-stuff/echo');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', async (data) => {
+      messages.push(data);
+
+      expect(messages).to.deep.equal([
+        'socket',
+        '/echo/.websocket',
+        'something',
+        'server response'
+      ]);
+      await got('http://localhost:3000/ws-stuff/echo');
+      expect(messages.pop()).to.equal('get route /ws-stuff/echo');
+
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      expressWsInstance.getWss().close(); // Close WS server
+      done();
+    });
+  });
+});
+
+describe('expressWsInstance `applyTo`', () => {
+  it('`applyTo` adds to router', () => {
+    const { Router: { ws } } = express;
+    delete express.Router.ws;
+    const expressWsInstance = expressWs(express(), null, {
+      leaveRouterUntouched: true
+    });
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(express.Router.ws).to.be.undefined;
+    const { applyTo } = expressWsInstance;
+
+    applyTo(express.Router);
+    expect(express.Router.ws).to.be.a('function');
+
+    express.Router.ws = ws;
+  });
+});
+
+describe('Error handling', () => {
+  it('Silently ignores failing middleware', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    app.get('/', (req, res /* , next */) => {
+      messages.push('get route');
+      res.end();
+    });
+
+    app.ws('/', (ws) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        ws.send('server response');
+      });
+      messages.push('socket');
+
+      throw new Error('Erring middleware!');
+    }, (err, req, res, next) => { // eslint-disable-line no-unused-vars
+      messages.push('error middleware 1');
+      throw new Error('another oops');
+    }, (err, req, res, next) => { // eslint-disable-line no-unused-vars
+      messages.push('error middleware 2');
+    });
+
+    const server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', async (data) => {
+      messages.push(data);
+      expect(messages).to.deep.equal([
+        'socket',
+        'error middleware 1',
+        'error middleware 2',
+        'something',
+        'server response'
+      ]);
+      await got('http://localhost:3000/');
+      expect(messages.pop()).to.equal('get route');
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      expressWsInstance.getWss().close(); // Close WS server
+      done();
+    });
+  });
+
+  it('Closes socket upon middleware setting erring `writeHead` status code', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    app.use((req, res, next) => {
+      messages.push('middleware 1');
+      res.writeHead(200);
+      return next();
+    }, (req, res, next) => {
+      messages.push('middleware 2');
+      res.writeHead(500);
+      return next();
+    });
+
+    app.get('/', (req, res /* , next */) => {
+      messages.push('get route');
+      res.end();
+    });
+
+    let server;
+    app.ws('/', (ws) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        try {
+          ws.send('server response');
+        } catch (err) {
+          expect(messages).to.deep.equal([
+            'middleware 1',
+            'middleware 2',
+            'socket',
+            'something',
+          ]);
+          expect(err.toString()).to.include('WebSocket is not open');
+          ws.terminate(); // Close WS client
+          server.close(); // Close HTTP server underlying WS server
+          expressWsInstance.getWss().close(); // Close WS server
+          done();
+        }
+      });
+      messages.push('socket');
+    });
+
+    server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', () => {
+    });
+  });
+
+  it('Silently recovers with HTTP requests passed through the underlying app', async () => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    app.ws('/', (ws, req) => {
+      messages.push('socket', req.url);
+    });
+
+    // Use this to avoid an error
+    app.get('/.websocket', (req, res /* , next */) => {
+      messages.push(`get route ${req.url}`);
+      res.end();
+    });
+
+    const server = app.listen(3000);
+
+    await got('http://localhost:3000/.websocket');
+
+    expect(messages).to.deep.equal([
+      'get route /.websocket'
+    ]);
+    server.close(); // Close HTTP server underlying WS server
+    expressWsInstance.getWss().close(); // Close WS server
+  });
+
+  it('Closes socket on request without matching WebSocket router', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    const server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/');
+
+    ws.on('open', () => {
+      messages.push('opened 1');
+    });
+    ws.on('close', () => {
+      expect(messages).to.deep.equal([
+        'opened 1'
+      ]);
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      done();
+    });
+  });
+});
+
+describe('params', () => {
+  it('Sets up routes with params', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messages = [];
+
+    app.param('world', (req, res, next, world) => {
+      req.world = world || 'world';
+      return next();
+    });
+
+    app.get('/hello/:world', (req, res, next) => {
+      messages.push('hello', req.world);
+      res.end();
+      next();
+    });
+
+    app.ws('/hello/:world', (ws, req, next) => {
+      ws.on('message', (msg) => {
+        messages.push(msg);
+        ws.send('server response');
+      });
+      messages.push('socket hello', req.world);
+      next();
+    });
+
+    const server = app.listen(3000);
+
+    const ws = new WebSocket('ws://localhost:3000/hello/earth');
+
+    ws.on('open', () => {
+      ws.send('something');
+    });
+
+    ws.on('message', (data) => {
+      messages.push(data);
+      expect(messages).to.deep.equal([
+        'socket hello',
+        'earth',
+        'something',
+        'server response'
+      ]);
+      ws.terminate(); // Close WS client
+      server.close(); // Close HTTP server underlying WS server
+      expressWsInstance.getWss().close(); // Close WS server
+      done();
+    });
+  });
+});
+
+describe('broadcast', () => {
+  it('Broadcasts to clients', (done) => {
+    const expressWsInstance = expressWs(express());
+    const { app } = expressWsInstance;
+
+    const messagesA = [];
+    const messagesB = [];
+    const wss = expressWsInstance.getWss();
+    app.ws('/a', (ws /* , req */) => {
+      ws.on('message', (msg) => {
+        messagesA.push(msg);
+        ws.send('server response');
+        wss.clients.forEach((client) => {
+          client.send('hello');
+        });
+      });
+      messagesA.push('a message');
+    });
+
+    app.ws('/b', (/* ws, req */) => {
+      messagesB.push('b message');
+    });
+
+    const server = app.listen(3000);
+    const expectedMessagesA = [
+      'a message',
+      'something',
+      'server response',
+      'hello',
+    ];
+    const expectedMessagesB = [
+      'b message',
+      'hello'
+    ];
+
+    let wsA;
+    let wsB;
+    let ready = false;
+    function finish() {
+      if (ready) {
+        wsA.terminate(); // Close WS client
+        wsB.terminate(); // Close WS client
+        server.close(); // Close HTTP server underlying WS server
+        expressWsInstance.getWss().close(); // Close WS server
+        done();
+      }
+      ready = true;
+    }
+
+    wsA = new WebSocket('ws://localhost:3000/a');
+
+    wsA.on('open', () => {
+      wsA.send('something');
+    });
+
+    wsA.on('message', (data) => {
+      messagesA.push(data);
+      if (messagesA.length < expectedMessagesA.length) {
+        return;
+      }
+      expect(messagesA).to.deep.equal(expectedMessagesA);
+      finish();
+    });
+
+    wsB = new WebSocket('ws://localhost:3000/b');
+
+    wsB.on('open', () => {
+      wsB.send('something');
+    });
+
+    wsB.on('message', (data) => {
+      messagesB.push(data);
+      if (messagesB.length < expectedMessagesB.length) {
+        return;
+      }
+      expect(messagesB).to.deep.equal(expectedMessagesB);
+      finish();
+    });
+  });
+});
+
+describe('Options', () => {
+  describe('`leaveRouterUntouched`', () => {
+    it('`leaveRouterUntouched` avoids adding to Router prototype', () => {
+      const { Router: { ws } } = express;
+      delete express.Router.ws;
+      expressWs(express(), null, {
+        leaveRouterUntouched: true
+      });
+
+      // eslint-disable-next-line no-unused-expressions
+      expect(express.Router.ws).to.be.undefined;
+
+      express.Router.ws = ws;
+    });
+  });
+});


### PR DESCRIPTION
Builds on #137.

The fixes/refactoring were part and parcel for adding full tests/coverage.

- Fix: Remove unused parameter passed to `getWss` in `broadcast.js` example (also renaming variable to reflect lack of specificity to route of web socket server)
- Fix: Allow middleware error handler (arity 4) to be triggered
- Refactoring: Remove `upgradeReq` check (dropped back in ws 3)
- Testing: Add mocha/chai/nyc

Re: middleware error handler, `Layer.prototype.handle_error` of `router` (used by `express.Router`) only handles arity 4, so we need to return a function that has arity 4.