### PR TITLE
Bump `ws`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+        registry-url: 'https://npm.pkg.github.com'
+    - name: Install
+      # Skip post-install to avoid malicious scripts stealing PAT
+      run: npm install --ignore-script
+      env:
+        # GITHUB_TOKEN can't access packages hosted in private repos,
+        # even within the same organisation
+        NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - name: Post-install
+      run: npm rebuild && npm run prepare --if-present
+    - name: Publish
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # Use PAT instead of default Github token, because the default
+        # token deliberately will not trigger another workflow run
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+        registry-url: 'https://npm.pkg.github.com'
+    - name: Install
+      # Skip post-install to avoid malicious scripts stealing PAT
+      run: npm install --ignore-script
+      env:
+        # GITHUB_TOKEN can't access packages hosted in private repos,
+        # even within the same organisation
+        NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - name: Post-install
+      run: npm rebuild && npm run prepare --if-present
+    - name: Lint
+      run: npm run lint
+    - name: Tag
+      if: ${{ github.ref == 'refs/heads/master' }}
+      run: ./tag.sh

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@reedsy:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) endpoints for [Express](http://expressjs.com/) applications. Lets you define WebSocket endpoints like any other type of route, and applies regular Express middleware. The WebSocket support is implemented with the help of the [ws](https://github.com/websockets/ws) library.
 
+## Why the Reedsy fork?
+
+We need to bump the version of `ws` to a more recent version. Sadly `npm` provides no mechanism to do this, so we fork instead.
+
 ## Installation
 
 `npm install --save express-ws`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-ws",
-  "version": "5.0.0",
+  "version": "5.0.0-reedsy-1.0.0",
   "description": "WebSocket endpoints for Express applications",
   "main": "index",
   "module": "src/index",
@@ -20,7 +20,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "esm": "^3.0.84",
-    "ws": "^6.0.0"
+    "ws": "^7.0.0"
   },
   "peerDependencies": {
     "express": "^4.0.0 || ^5.0.0-alpha.1"

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+VERSION=$(node -p "require('./package.json').version")
+
+git config --local user.email "github@reedsy.com"
+git config --local user.name "GitHub Action"
+git fetch --tags
+
+VERSION_COUNT=$(git tag --list $VERSION | wc -l)
+
+if [ $VERSION_COUNT -gt 0 ]
+then
+  echo "Version $VERSION already deployed."
+  exit 0
+else
+  echo "Deploying version $VERSION"
+fi
+
+echo '!/lib' >> .gitignore
+
+git checkout -b release-$VERSION
+git add .gitignore
+git add --all lib/
+git commit --message "Release version $VERSION"
+git tag $VERSION
+git push origin refs/tags/$VERSION


### PR DESCRIPTION
This change is our reason for forking: bumping `ws` to the latest
version.

The primary purpose for this is that older versions of `ws` have a bug
where they don't emit a `'close'` event properly on closing.

However, we also should use the latest version for security reasons.