### PR TITLE
Handle async middleware

### DIFF
--- a/src/wrap-middleware.js
+++ b/src/wrap-middleware.js
@@ -1,10 +1,10 @@
 export default function wrapMiddleware(middleware) {
-  return (req, res, next) => {
+  return async (req, res, next) => {
     if (req.ws !== null && req.ws !== undefined) {
       req.wsHandled = true;
       try {
         /* Unpack the `.ws` property and call the actual handler. */
-        middleware(req.ws, req, next);
+        await middleware(req.ws, req, next);
       } catch (err) {
         /* If an error is thrown, let's send that on to any error handling */
         next(err);


### PR DESCRIPTION
# Current Behaviour

Middlewares are called in a try catch to handle errors.

This works as expected for synchronous middlewares but asynchronous middlewares errors are not caught.

# Solution

Add an await to the middleware call.

No changes expected for synchronous middlewares.

# Temporary solution

This branch was deployed to https://www.npmjs.com/package/express-ws-await while merging this MR.